### PR TITLE
Refactor for Fusion 3.x compatibility and fixes

### DIFF
--- a/analyzer/extractor/Dockerfile
+++ b/analyzer/extractor/Dockerfile
@@ -1,4 +1,12 @@
 # =============================================================================
+# FUSION DIRECTIVES
+# =============================================================================
+# fusion:image=cert-edf/helium-be-extractor
+# fusion:package=generaptor
+# fusion:package=edf-fusion
+# fusion:package=edf-helium-core
+# fusion:package=edf-helium-server
+# =============================================================================
 # BUILD IMAGE
 # =============================================================================
 FROM python:3.12-alpine AS build
@@ -6,17 +14,21 @@ FROM python:3.12-alpine AS build
 # ENVIRONMENT
 # ------------------------------------------------------------------------------
 #
-# -----------------------------------------------------------------------------
-# COPY PRE-BUILT PACKAGES (OPTIONAL)
-# -----------------------------------------------------------------------------
-#COPY pkg /pkg
 # ------------------------------------------------------------------------------
 # SETUP VENV
 # ------------------------------------------------------------------------------
 RUN apk add build-base linux-headers && \
     python3 -m venv /venv && \
-    /venv/bin/python -m pip install uv && \
-    /venv/bin/uv pip install --python /venv/bin/python edf-helium-server
+    /venv/bin/python -m pip install uv
+# -----------------------------------------------------------------------------
+# SETUP FUSION PACKAGES (PROD)
+# -----------------------------------------------------------------------------
+RUN /venv/bin/uv pip install --python /venv/bin/python edf-helium-server
+# -----------------------------------------------------------------------------
+# SETUP FUSION PACKAGES (DEV)
+# -----------------------------------------------------------------------------
+#COPY pkg /pkg
+#RUN /venv/bin/uv pip install --python /venv/bin/python --pre --find-links /pkg edf-helium-server
 # =============================================================================
 # PRODUCTION IMAGE
 # =============================================================================

--- a/analyzer/extractor/analyzer.py
+++ b/analyzer/extractor/analyzer.py
@@ -24,7 +24,6 @@ async def _extractor_process_impl(
     analysis_storage = storage.analysis_storage(
         a_task.case.guid, a_task.collection.guid, a_task.analysis.analyzer
     )
-    analysis_storage.data_dir.mkdir(parents=True, exist_ok=True)
     src = collection_storage.data_dir.resolve()
     dst = analysis_storage.data_dir.resolve()
     try:

--- a/analyzer/hayabusa/Dockerfile
+++ b/analyzer/hayabusa/Dockerfile
@@ -1,4 +1,12 @@
 # =============================================================================
+# FUSION DIRECTIVES
+# =============================================================================
+# fusion:image=cert-edf/helium-be-hayabusa
+# fusion:package=generaptor
+# fusion:package=edf-fusion
+# fusion:package=edf-helium-core
+# fusion:package=edf-helium-server
+# =============================================================================
 # ENV IMAGE
 # =============================================================================
 FROM python:3.12-alpine AS env
@@ -6,7 +14,7 @@ FROM python:3.12-alpine AS env
 # ENVIRONMENT
 # ------------------------------------------------------------------------------
 ENV HAYABUSA_LIBC=musl
-ENV HAYABUSA_VERSION=3.6.0
+ENV HAYABUSA_VERSION=3.8.1
 # =============================================================================
 # BUILD IMAGE
 # =============================================================================
@@ -25,9 +33,17 @@ ENV HAYABUSA_URL=https://github.com/Yamato-Security/hayabusa/releases/download/v
 RUN apk add build-base curl linux-headers && \
     python3 -m venv /venv && \
     /venv/bin/python -m pip install uv && \
-    /venv/bin/uv pip install --python /venv/bin/python edf-helium-server && \
     mkdir /tpl && \
     curl -L -o /tpl/hayabusa.zip ${HAYABUSA_URL}
+# -----------------------------------------------------------------------------
+# SETUP FUSION PACKAGES (PROD)
+# -----------------------------------------------------------------------------
+RUN /venv/bin/uv pip install --python /venv/bin/python edf-helium-server
+# -----------------------------------------------------------------------------
+# SETUP FUSION PACKAGES (DEV)
+# -----------------------------------------------------------------------------
+#COPY pkg /pkg
+#RUN /venv/bin/uv pip install --python /venv/bin/python --pre --find-links /pkg edf-helium-server
 # =============================================================================
 # PRODUCTION IMAGE
 # =============================================================================

--- a/analyzer/plasma/Dockerfile
+++ b/analyzer/plasma/Dockerfile
@@ -1,4 +1,15 @@
 # =============================================================================
+# FUSION DIRECTIVES
+# =============================================================================
+# fusion:image=cert-edf/helium-be-plasma
+# fusion:package=generaptor
+# fusion:package=edf-plasma-core
+# fusion:package=edf-plasma-dissectors
+# fusion:package=edf-plasma-cli
+# fusion:package=edf-fusion
+# fusion:package=edf-helium-core
+# fusion:package=edf-helium-server
+# =============================================================================
 # BUILD IMAGE
 # =============================================================================
 FROM ubuntu:24.04 AS build
@@ -16,10 +27,16 @@ FROM ubuntu:24.04 AS build
 RUN apt update && \
     apt install --yes build-essential libmagic-dev libsystemd-dev pkg-config python3 python3-dev python3-venv && \
     python3 -m venv /venv && \
-    /venv/bin/python -m pip install uv && \
-    /venv/bin/uv pip install --python /venv/bin/python edf-helium-server \
-                                                       edf-plasma-dissectors[binary,linux,windows,pcap,memdump] \
-                                                       edf-plasma-cli
+    /venv/bin/python -m pip install uv
+# -----------------------------------------------------------------------------
+# SETUP FUSION PACKAGES (PROD)
+# -----------------------------------------------------------------------------
+RUN /venv/bin/uv pip install --python /venv/bin/python edf-helium-server edf-plasma-dissectors[binary,linux,windows,pcap,memdump] edf-plasma-cli
+# -----------------------------------------------------------------------------
+# SETUP FUSION PACKAGES (DEV)
+# -----------------------------------------------------------------------------
+#COPY pkg /pkg
+#RUN /venv/bin/uv pip install --python /venv/bin/python --pre --find-links /pkg edf-helium-server edf-plasma-dissectors[binary,linux,windows,pcap,memdump] edf-plasma-cli
 # =============================================================================
 # PRODUCTION IMAGE
 # =============================================================================

--- a/analyzer/plaso/Dockerfile
+++ b/analyzer/plaso/Dockerfile
@@ -1,4 +1,12 @@
 # =============================================================================
+# FUSION DIRECTIVES
+# =============================================================================
+# fusion:image=cert-edf/helium-be-plaso
+# fusion:package=edf-fusion
+# fusion:package=generaptor
+# fusion:package=edf-helium-core
+# fusion:package=edf-helium-server
+# =============================================================================
 # BUILD IMAGE
 # =============================================================================
 FROM ubuntu:24.04 AS build
@@ -17,7 +25,16 @@ RUN apt update && \
     apt install --yes build-essential nano pkg-config python3 python3-dev python3-venv && \
     python3 -m venv /venv && \
     /venv/bin/python -m pip install uv && \
-    /venv/bin/uv pip install --python /venv/bin/python edf-helium-server plaso
+    /venv/bin/uv pip install --python /venv/bin/python plaso
+# -----------------------------------------------------------------------------
+# SETUP FUSION PACKAGES (PROD)
+# -----------------------------------------------------------------------------
+RUN /venv/bin/uv pip install --python /venv/bin/python edf-helium-server
+# -----------------------------------------------------------------------------
+# SETUP FUSION PACKAGES (DEV)
+# -----------------------------------------------------------------------------
+#COPY pkg /pkg
+#RUN /venv/bin/uv pip install --python /venv/bin/python --pre --find-links /pkg edf-helium-server
 # =============================================================================
 # PRODUCTION IMAGE
 # =============================================================================

--- a/analyzer/yara/Dockerfile
+++ b/analyzer/yara/Dockerfile
@@ -1,4 +1,12 @@
 # =============================================================================
+# FUSION DIRECTIVES
+# =============================================================================
+# fusion:image=cert-edf/helium-be-yara
+# fusion:package=edf-fusion
+# fusion:package=generaptor
+# fusion:package=edf-helium-core
+# fusion:package=edf-helium-server
+# =============================================================================
 # BUILD IMAGE
 # =============================================================================
 FROM python:3.12-alpine AS build
@@ -16,9 +24,17 @@ ENV YARA_RULES_URL=https://github.com/Yara-Rules/rules/archive/refs/heads/master
 RUN apk add build-base curl linux-headers && \
     python3 -m venv /venv && \
     /venv/bin/python -m pip install uv && \
-    /venv/bin/uv pip install --python /venv/bin/python edf-helium-server && \
     mkdir /tpl && \
     curl -L -o /tpl/yara-rules.zip ${YARA_RULES_URL}
+# -----------------------------------------------------------------------------
+# SETUP FUSION PACKAGES (PROD)
+# -----------------------------------------------------------------------------
+RUN /venv/bin/uv pip install --python /venv/bin/python edf-helium-server
+# -----------------------------------------------------------------------------
+# SETUP FUSION PACKAGES (DEV)
+# -----------------------------------------------------------------------------
+#COPY pkg /pkg
+#RUN /venv/bin/uv pip install --python /venv/bin/python --pre --find-links /pkg edf-helium-server
 # =============================================================================
 # PRODUCTION IMAGE
 # =============================================================================

--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
     "Topic :: Security",
 ]
 dependencies = [
-    "edf-helium-core~=2.0",
+    "edf-helium-core~=3.0",
 ]
 
 

--- a/client/test/client.py
+++ b/client/test/client.py
@@ -3,6 +3,7 @@
 
 from argparse import ArgumentParser
 from asyncio import run, sleep
+from dataclasses import dataclass
 from pathlib import Path
 
 from edf_fusion.client import (
@@ -17,6 +18,7 @@ from edf_fusion.client import (
 )
 from edf_fusion.helper.datetime import from_iso
 from edf_fusion.helper.logging import get_logger
+from edf_fusion.helper.serializing import Loadable
 from edf_helium_core.concept import (
     Analysis,
     Case,
@@ -25,10 +27,8 @@ from edf_helium_core.concept import (
     Constant,
     Priority,
 )
-from generaptor.concept import Architecture, Distribution, OperatingSystem
-from yarl import URL
-
 from edf_helium_client import HeliumClient
+from generaptor.concept import Architecture, Distribution, OperatingSystem
 
 _LOGGER = get_logger('client', root='test')
 _TEST_FILE = Path(__file__).parent / 'auth.log.zip'
@@ -49,10 +49,12 @@ async def _test_retrieve_constant(fusion_client: FusionClient):
     _LOGGER.info("retrieved constant: %s", constant)
 
 
-async def _test_case_lifecycle(fusion_case_api_client: FusionCaseAPIClient):
+async def _test_case_lifecycle(
+    fusion_case_api_client: FusionCaseAPIClient, acs: set[str]
+):
     # create case
     case = await fusion_case_api_client.create_case(
-        Case(tsid=None, name='T', description='D', acs={'test'})
+        Case(tsid=None, name='T', description='D', acs=acs)
     )
     _LOGGER.info("created case: %s", case)
     # update case
@@ -228,7 +230,7 @@ async def _test_analyzer_lifecyle(
     _LOGGER.info("analysis deleted: %s", deleted)
 
 
-async def _playbook(fusion_client: FusionClient):
+async def _playbook(fusion_client: FusionClient, acs: set[str]):
     fusion_case_api_client = FusionCaseAPIClient(
         case_cls=Case, fusion_client=fusion_client
     )
@@ -239,9 +241,9 @@ async def _playbook(fusion_client: FusionClient):
     await _test_retrieve_info(fusion_client)
     await _test_retrieve_constant(fusion_client)
     await _test_retrieve_disk_usage(helium_client)
-    await _test_case_lifecycle(fusion_case_api_client)
+    await _test_case_lifecycle(fusion_case_api_client, acs)
     case = await fusion_case_api_client.create_case(
-        Case(tsid=None, name='T', description='D', acs={'test'})
+        Case(tsid=None, name='T', description='D', acs=acs)
     )
     _LOGGER.info("created case: %s", case)
     input("execution paused, press enter to continue!")
@@ -264,35 +266,46 @@ async def _playbook(fusion_client: FusionClient):
     await fusion_case_api_client.delete_case(case.guid)
 
 
+@dataclass(kw_only=True)
+class TestConfig(Loadable):
+    """Test configuration"""
+
+    url: str
+    key: str
+
+    @classmethod
+    def from_dict(cls, dct):
+        return cls(url=dct['url'], key=dct['key'])
+
+
 def _parse_args():
     parser = ArgumentParser()
-    parser.add_argument(
-        '--api-url',
-        type=URL,
-        default=URL('http://helium.domain.lan/'),
-        help="API URL",
-    )
-    return parser.parse_args()
+    parser.add_argument('config', type=Path, help="Test configuration")
+    args = parser.parse_args()
+    args.config = TestConfig.from_filepath(args.config)
+    return args
 
 
 async def app():
     """Application entrypoint"""
     args = _parse_args()
-    config = FusionClientConfig(api_url=args.api_url)
+    config = FusionClientConfig(
+        api_url=args.config.url, api_key=args.config.key
+    )
     session = create_session(config, unsafe=True)
     async with session:
         fusion_client = FusionClient(config=config, session=session)
         fusion_auth_api_client = FusionAuthAPIClient(
             fusion_client=fusion_client
         )
-        identity = await fusion_auth_api_client.login('test', 'test')
+        identity = await fusion_auth_api_client.is_logged()
         if not identity:
             return
         _LOGGER.info("logged as: %s", identity)
         try:
-            await _playbook(fusion_client)
-        finally:
-            await fusion_auth_api_client.logout()
+            await _playbook(fusion_client, {identity.username})
+        except:
+            _LOGGER.exception("exception raised!")
 
 
 if __name__ == '__main__':

--- a/client/test/subscribe.py
+++ b/client/test/subscribe.py
@@ -3,6 +3,8 @@
 
 from argparse import ArgumentParser
 from asyncio import run
+from dataclasses import dataclass
+from pathlib import Path
 from uuid import UUID
 
 from edf_fusion.client import (
@@ -14,6 +16,7 @@ from edf_fusion.client import (
     create_session,
 )
 from edf_fusion.helper.logging import get_logger
+from edf_fusion.helper.serializing import Loadable
 from edf_helium_core.concept import Case
 from yarl import URL
 
@@ -30,16 +33,25 @@ async def _playbook(fusion_client: FusionClient, case_guid: UUID):
         _LOGGER.info("%s", event)
 
 
+@dataclass(kw_only=True)
+class TestConfig(Loadable):
+    """Test configuration"""
+
+    url: str
+    key: str
+
+    @classmethod
+    def from_dict(cls, dct):
+        return cls(url=dct['url'], key=dct['key'])
+
+
 def _parse_args():
     parser = ArgumentParser()
-    parser.add_argument(
-        '--api-url',
-        type=URL,
-        default=URL('http://helium.domain.lan/'),
-        help="API URL",
-    )
+    parser.add_argument('config', type=Path, help="Test configuration")
     parser.add_argument('case_guid', type=UUID, help="Case GUID")
-    return parser.parse_args()
+    args = parser.parse_args()
+    args.config = TestConfig.from_filepath(args.config)
+    return args
 
 
 async def app():
@@ -52,14 +64,14 @@ async def app():
         fusion_auth_api_client = FusionAuthAPIClient(
             fusion_client=fusion_client
         )
-        identity = await fusion_auth_api_client.login('test', 'test')
+        identity = await fusion_auth_api_client.is_logged()
         if not identity:
             return
         _LOGGER.info("logged as: %s", identity)
         try:
             await _playbook(fusion_client, args.case_guid)
-        finally:
-            await fusion_auth_api_client.logout()
+        except:
+            _LOGGER.exception("exception raised!")
 
 
 if __name__ == '__main__':

--- a/compose.yml
+++ b/compose.yml
@@ -39,7 +39,8 @@ services:
       - helium-redis
     environment:
       ROLE: server
-      FUSION_DEBUG: 0
+      COLUMNS: ${COLUMNS:-120}
+      FUSION_DEBUG: ${FUSION_DEBUG:-0}
 
   helium-disk-usage:
     build:
@@ -56,7 +57,8 @@ services:
       - helium-redis
     environment:
       ROLE: disk-usage
-      FUSION_DEBUG: 0
+      COLUMNS: ${COLUMNS:-120}
+      FUSION_DEBUG: ${FUSION_DEBUG:-0}
 
   helium-synchronizer:
     build:
@@ -70,7 +72,8 @@ services:
       - /data/syncfs:/syncfs
     environment:
       ROLE: synchronizer
-      FUSION_DEBUG: 0
+      COLUMNS: ${COLUMNS:-120}
+      FUSION_DEBUG: ${FUSION_DEBUG:-0}
 
   helium-analyzer-extractor:
     build:
@@ -87,7 +90,8 @@ services:
       - helium-redis
     environment:
       ROLE: analyzer
-      FUSION_DEBUG: 0
+      COLUMNS: ${COLUMNS:-120}
+      FUSION_DEBUG: ${FUSION_DEBUG:-0}
 
   helium-analyzer-hayabusa:
     build:
@@ -105,7 +109,8 @@ services:
       - helium-redis
     environment:
       ROLE: analyzer
-      FUSION_DEBUG: 0
+      COLUMNS: ${COLUMNS:-120}
+      FUSION_DEBUG: ${FUSION_DEBUG:-0}
 
   helium-analyzer-plasma:
     build:
@@ -122,7 +127,8 @@ services:
       - helium-redis
     environment:
       ROLE: analyzer
-      FUSION_DEBUG: 0
+      COLUMNS: ${COLUMNS:-120}
+      FUSION_DEBUG: ${FUSION_DEBUG:-0}
 
   helium-analyzer-plaso:
     build:
@@ -139,7 +145,8 @@ services:
       - helium-redis
     environment:
       ROLE: analyzer
-      FUSION_DEBUG: 0
+      COLUMNS: ${COLUMNS:-120}
+      FUSION_DEBUG: ${FUSION_DEBUG:-0}
 
   helium-analyzer-yara:
     build:
@@ -157,7 +164,8 @@ services:
       - helium-redis
     environment:
       ROLE: analyzer
-      FUSION_DEBUG: 0
+      COLUMNS: ${COLUMNS:-120}
+      FUSION_DEBUG: ${FUSION_DEBUG:-0}
 
 networks:
   private:

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
     "Topic :: Security",
 ]
 dependencies = [
-    "edf-fusion~=2.0",
+    "edf-fusion~=3.0",
     "generaptor~=15.4",
 ]
 

--- a/server/docker/Dockerfile
+++ b/server/docker/Dockerfile
@@ -1,11 +1,15 @@
 # =============================================================================
+# FUSION DIRECTIVES
+# =============================================================================
+# fusion:image=cert-edf/helium-be
+# fusion:package=generaptor
+# fusion:package=edf-fusion
+# fusion:package=edf-helium-core
+# fusion:package=edf-helium-server
+# =============================================================================
 # BUILD IMAGE
 # =============================================================================
 FROM python:3.12-alpine AS build
-# -----------------------------------------------------------------------------
-# COPY PRE-BUILT PACKAGES (OPTIONAL)
-# -----------------------------------------------------------------------------
-#COPY pkg /pkg
 # -----------------------------------------------------------------------------
 # COPY TEMPLATES
 # -----------------------------------------------------------------------------
@@ -16,8 +20,20 @@ COPY tpl /tpl
 RUN apk add build-base zip linux-headers && \
     python3 -m venv /venv && \
     /venv/bin/python -m pip install uv && \
-    /venv/bin/uv pip install --python /venv/bin/python argon2-cffi python-keycloak edf-helium-server && \
-    /venv/bin/generaptor --cache /tpl/generaptor/cache update && \
+    /venv/bin/uv pip install --python /venv/bin/python argon2-cffi python-keycloak
+# -----------------------------------------------------------------------------
+# SETUP FUSION PACKAGES (PROD)
+# -----------------------------------------------------------------------------
+RUN /venv/bin/uv pip install --python /venv/bin/python edf-helium-server
+# -----------------------------------------------------------------------------
+# SETUP FUSION PACKAGES (DEV)
+# -----------------------------------------------------------------------------
+#COPY pkg /pkg
+#RUN /venv/bin/uv pip install --python /venv/bin/python --pre --find-links /pkg edf-helium-server
+# -----------------------------------------------------------------------------
+# INITIALIZE GENERAPTOR
+# -----------------------------------------------------------------------------
+RUN /venv/bin/generaptor --cache /tpl/generaptor/cache update && \
     cd /tpl && \
     zip -r generaptor.zip generaptor/ && \
     rm -rf generaptor/

--- a/server/edf_helium_server/analyzer/__init__.py
+++ b/server/edf_helium_server/analyzer/__init__.py
@@ -190,7 +190,7 @@ class Analyzer:
             self._config.event_api.api_key, self._config.event_api.timeout
         )
         self._redis = create_redis(self._config.server.redis_url)
-        self._storage = Storage(config=self._config.storage)
+        self._storage = Storage(redis=self._redis, config=self._config.storage)
         async with session:
             self._notifier = FusionNotifier(
                 redis=self._redis,

--- a/server/edf_helium_server/api/case.py
+++ b/server/edf_helium_server/api/case.py
@@ -11,6 +11,7 @@ from edf_fusion.helper.aiohttp import (
 )
 from edf_fusion.helper.logging import get_logger
 from edf_fusion.helper.streaming import stream_from_file
+from edf_fusion.server.auth import Action
 from edf_fusion.server.case import (
     AttachContext,
     CreateContext,
@@ -87,11 +88,11 @@ async def api_analyses_get(request: Request):
     """Enumerate case collection analyses"""
     case_guid = get_guid(request, 'case_guid')
     collection_guid = get_guid(request, 'collection_guid')
-    _, storage = await prologue(
-        request,
-        'enumerate_analyses',
+    action = Action(
+        name='enumerate_analyses',
         context={'case_guid': case_guid, 'collection_guid': collection_guid},
     )
+    _, storage = await prologue(request, action)
     return json_response(
         data=[
             analysis.to_dict()
@@ -108,17 +109,17 @@ async def api_analysis_delete(request: Request):
     collection_guid = get_guid(request, 'collection_guid')
     fusion_evt_api = get_fusion_evt_api(request)
     analyzer = request.match_info['analyzer']
-    _, storage = await prologue(
-        request,
-        'delete_analysis',
+    action = Action(
+        name='delete_analysis',
+        change=True,
+        delete=True,
         context={
             'case_guid': case_guid,
             'collection_guid': collection_guid,
             'analyzer': analyzer,
-            'case_open_check': True,
-            'is_delete_op': True,
         },
     )
+    _, storage = await prologue(request, action)
     case = await storage.retrieve_case(case_guid)
     analysis = await storage.retrieve_analysis(
         case_guid, collection_guid, analyzer
@@ -143,16 +144,16 @@ async def api_analysis_log_get(request: Request) -> StreamResponse:
     case_guid = get_guid(request, 'case_guid')
     collection_guid = get_guid(request, 'collection_guid')
     analyzer = request.match_info['analyzer']
-    _, storage = await prologue(
-        request,
-        'download_analysis_log',
+    action = Action(
+        name='download_analysis_log',
         context={
             'case_guid': case_guid,
             'collection_guid': collection_guid,
             'analyzer': analyzer,
         },
     )
-    log = storage.retrieve_analysis_log(
+    _, storage = await prologue(request, action)
+    log = await storage.retrieve_analysis_log(
         case_guid, collection_guid, analyzer
     )
     if not log:
@@ -171,15 +172,15 @@ async def api_analysis_download_get(request: Request):
     collection_guid = get_guid(request, 'collection_guid')
     fusion_dl_api = get_fusion_dl_api(request)
     analyzer = request.match_info['analyzer']
-    _, storage = await prologue(
-        request,
-        'download_analysis_data',
+    action = Action(
+        name='download_analysis_data',
         context={
             'case_guid': case_guid,
             'collection_guid': collection_guid,
             'analyzer': analyzer,
         },
     )
+    _, storage = await prologue(request, action)
     filepath = await storage.retrieve_analysis_data(
         case_guid, collection_guid, analyzer
     )
@@ -199,15 +200,15 @@ async def api_analysis_get(request: Request):
     case_guid = get_guid(request, 'case_guid')
     collection_guid = get_guid(request, 'collection_guid')
     analyzer = request.match_info['analyzer']
-    _, storage = await prologue(
-        request,
-        'retrieve_analysis',
+    action = Action(
+        name='retrieve_analysis',
         context={
             'case_guid': case_guid,
             'collection_guid': collection_guid,
             'analyzer': analyzer,
         },
     )
+    _, storage = await prologue(request, action)
     analysis = await storage.retrieve_analysis(
         case_guid, collection_guid, analyzer
     )
@@ -221,15 +222,12 @@ async def api_analysis_post(request: Request):
     case_guid = get_guid(request, 'case_guid')
     collection_guid = get_guid(request, 'collection_guid')
     fusion_evt_api = get_fusion_evt_api(request)
-    _, storage = await prologue(
-        request,
-        'create_analysis',
-        context={
-            'case_guid': case_guid,
-            'collection_guid': collection_guid,
-            'case_open_check': True,
-        },
+    action = Action(
+        name='create_analysis',
+        change=True,
+        context={'case_guid': case_guid, 'collection_guid': collection_guid},
     )
+    _, storage = await prologue(request, action)
     body = await get_json_body(request)
     try:
         analysis = await storage.create_analysis(
@@ -255,16 +253,16 @@ async def api_analysis_put(request: Request):
     case_guid = get_guid(request, 'case_guid')
     collection_guid = get_guid(request, 'collection_guid')
     analyzer = request.match_info['analyzer']
-    _, storage = await prologue(
-        request,
-        'update_analysis',
+    action = Action(
+        name='update_analysis',
+        change=True,
         context={
             'case_guid': case_guid,
             'collection_guid': collection_guid,
             'analyzer': analyzer,
-            'case_open_check': True,
         },
     )
+    _, storage = await prologue(request, action)
     body = await get_json_body(request)
     dct = {'status': Status.PENDING.value}
     priority = body.get('priority')
@@ -283,16 +281,13 @@ async def api_collection_cache_delete(request: Request):
     """Delete collection case directory"""
     case_guid = get_guid(request, 'case_guid')
     collection_guid = get_guid(request, 'collection_guid')
-    _, storage = await prologue(
-        request,
-        'delete_collection_cache',
-        context={
-            'case_guid': case_guid,
-            'collection_guid': collection_guid,
-            'case_open_check': True,
-            # is_delete_op is not expected to be set here
-        },
+    action = Action(
+        name='delete_collection_cache',
+        change=True,
+        delete=False,  # anyone can delete cached data
+        context={'case_guid': case_guid, 'collection_guid': collection_guid},
     )
+    _, storage = await prologue(request, action)
     deleted = await storage.delete_collection_cache(case_guid, collection_guid)
     if not deleted:
         return json_response(status=404, message="Collection cache is empty")
@@ -304,16 +299,13 @@ async def api_collection_delete(request: Request):
     case_guid = get_guid(request, 'case_guid')
     collection_guid = get_guid(request, 'collection_guid')
     fusion_evt_api = get_fusion_evt_api(request)
-    _, storage = await prologue(
-        request,
-        'delete_collection',
-        context={
-            'case_guid': case_guid,
-            'collection_guid': collection_guid,
-            'case_open_check': True,
-            'is_delete_op': True,
-        },
+    action = Action(
+        name='delete_collection',
+        change=True,
+        delete=True,
+        context={'case_guid': case_guid, 'collection_guid': collection_guid},
     )
+    _, storage = await prologue(request, action)
     case = await storage.retrieve_case(case_guid)
     collection = await storage.retrieve_collection(case_guid, collection_guid)
     deleted = await storage.delete_collection(case_guid, collection_guid)
@@ -332,17 +324,17 @@ async def api_collection_download_get(request: Request):
     case_guid = get_guid(request, 'case_guid')
     collection_guid = get_guid(request, 'collection_guid')
     fusion_dl_api = get_fusion_dl_api(request)
-    _, storage = await prologue(
-        request,
-        'collection_download',
+    action = Action(
+        name='download_collection',
         context={'case_guid': case_guid, 'collection_guid': collection_guid},
     )
+    _, storage = await prologue(request, action)
     filepath = await storage.retrieve_collection_data(
         case_guid, collection_guid
     )
     if not filepath:
         return json_response(status=404, message="Collection not found")
-    pdk = await fusion_dl_api.prepare(filepath, f"{collection_guid}.zip")
+    pdk = await fusion_dl_api.prepare(filepath, f'{collection_guid}.zip')
     if not pdk:
         return json_response(
             status=503, message="Cannot process more download requests for now"
@@ -354,11 +346,11 @@ async def api_collection_get(request: Request):
     """Retrieve case collection metadata"""
     case_guid = get_guid(request, 'case_guid')
     collection_guid = get_guid(request, 'collection_guid')
-    _, storage = await prologue(
-        request,
-        'retrieve_collection',
+    action = Action(
+        name='retrieve_collection',
         context={'case_guid': case_guid, 'collection_guid': collection_guid},
     )
+    _, storage = await prologue(request, action)
     collection = await storage.retrieve_collection(case_guid, collection_guid)
     if not collection:
         return json_response(status=404, message="Collection not found")
@@ -369,11 +361,12 @@ async def api_collection_post(request: Request):
     """Create case collection"""
     case_guid = get_guid(request, 'case_guid')
     fusion_evt_api = get_fusion_evt_api(request)
-    _, storage = await prologue(
-        request,
-        'create_collection',
-        context={'case_guid': case_guid, 'case_open_check': True},
+    action = Action(
+        name='create_collection',
+        change=True,
+        context={'case_guid': case_guid},
     )
+    _, storage = await prologue(request, action)
     collection = None
     async for part in stream_multipart_parts(request, {'file'}):
         if collection:
@@ -402,15 +395,12 @@ async def api_collection_put(request: Request):
     case_guid = get_guid(request, 'case_guid')
     collection_guid = get_guid(request, 'collection_guid')
     fusion_evt_api = get_fusion_evt_api(request)
-    _, storage = await prologue(
-        request,
-        'update_collection',
-        context={
-            'case_guid': case_guid,
-            'collection_guid': collection_guid,
-            'case_open_check': True,
-        },
+    action = Action(
+        name='update_collection',
+        change=True,
+        context={'case_guid': case_guid, 'collection_guid': collection_guid},
     )
+    _, storage = await prologue(request, action)
     body = await get_json_body(request)
     collection = await storage.update_collection(
         case_guid, collection_guid, body
@@ -432,9 +422,10 @@ async def api_collection_put(request: Request):
 async def api_collections_get(request: Request):
     """Enumerate case collections"""
     case_guid = get_guid(request, 'case_guid')
-    _, storage = await prologue(
-        request, 'enumerate_collections', context={'case_guid': case_guid}
+    action = Action(
+        name='enumerate_collections', context={'case_guid': case_guid}
     )
+    _, storage = await prologue(request, action)
     return json_response(
         data=[
             collection.to_dict()
@@ -447,17 +438,12 @@ async def api_collector_config_get(request: Request):
     """Retrieve collector config"""
     case_guid = get_guid(request, 'case_guid')
     collector_guid = get_guid(request, 'collector_guid')
-    _, storage = await prologue(
-        request,
-        'download_collector_config',
-        context={
-            'case_guid': case_guid,
-            'collector_guid': collector_guid,
-        },
+    action = Action(
+        name='download_collector_config',
+        context={'case_guid': case_guid, 'collector_guid': collector_guid},
     )
-    config = storage.retrieve_collector_config(
-        case_guid, collector_guid
-    )
+    _, storage = await prologue(request, action)
+    config = storage.retrieve_collector_config(case_guid, collector_guid)
     if not config:
         return json_response(status=404, message="Collector config not found")
     response = await stream_response(
@@ -473,16 +459,13 @@ async def api_collector_delete(request: Request):
     case_guid = get_guid(request, 'case_guid')
     collector_guid = get_guid(request, 'collector_guid')
     fusion_evt_api = get_fusion_evt_api(request)
-    _, storage = await prologue(
-        request,
-        'delete_collector',
-        context={
-            'case_guid': case_guid,
-            'collector_guid': collector_guid,
-            'case_open_check': True,
-            'is_delete_op': True,
-        },
+    action = Action(
+        name='delete_collector',
+        change=True,
+        delete=True,
+        context={'case_guid': case_guid, 'collector_guid': collector_guid},
     )
+    _, storage = await prologue(request, action)
     case = await storage.retrieve_case(case_guid)
     collector = await storage.retrieve_collector(case_guid, collector_guid)
     deleted = await storage.delete_collector(case_guid, collector_guid)
@@ -501,11 +484,11 @@ async def api_collector_download_get(request: Request):
     case_guid = get_guid(request, 'case_guid')
     collector_guid = get_guid(request, 'collector_guid')
     fusion_dl_api = get_fusion_dl_api(request)
-    _, storage = await prologue(
-        request,
-        'download_collector',
+    action = Action(
+        name='download_collector',
         context={'case_guid': case_guid, 'collector_guid': collector_guid},
     )
+    _, storage = await prologue(request, action)
     executable = await storage.retrieve_collector_executable(
         case_guid, collector_guid
     )
@@ -523,11 +506,11 @@ async def api_collector_get(request: Request):
     """Retrieve case collector metadata"""
     case_guid = get_guid(request, 'case_guid')
     collector_guid = get_guid(request, 'collector_guid')
-    _, storage = await prologue(
-        request,
-        'retrieve_collector',
+    action = Action(
+        name='retrieve_collector',
         context={'case_guid': case_guid, 'collector_guid': collector_guid},
     )
+    _, storage = await prologue(request, action)
     collector = await storage.retrieve_collector(case_guid, collector_guid)
     if not collector:
         return json_response(status=404, message="Collector not found")
@@ -538,11 +521,12 @@ async def api_collector_post(request: Request):
     """Create case collector"""
     case_guid = get_guid(request, 'case_guid')
     fusion_evt_api = get_fusion_evt_api(request)
-    _, storage = await prologue(
-        request,
-        'create_collector',
-        context={'case_guid': case_guid, 'case_open_check': True},
+    action = Action(
+        name='create_collector',
+        change=True,
+        context={'case_guid': case_guid},
     )
+    _, storage = await prologue(request, action)
     body = await get_json_body(request)
     collector = await storage.create_collector(case_guid, body)
     if not collector:
@@ -561,11 +545,12 @@ async def api_collector_import_post(request: Request):
     """Import case collector (without binary)"""
     case_guid = get_guid(request, 'case_guid')
     fusion_evt_api = get_fusion_evt_api(request)
-    _, storage = await prologue(
-        request,
-        'import_collector',
-        context={'case_guid': case_guid, 'case_open_check': True},
+    action = Action(
+        name='import_collector',
+        change=True,
+        context={'case_guid': case_guid},
     )
+    _, storage = await prologue(request, action)
     body = await get_json_body(request)
     collector = await storage.import_collector(case_guid, body)
     if not collector:
@@ -584,11 +569,11 @@ async def api_collector_secrets_get(request: Request):
     """Retrieve case collector secrets"""
     case_guid = get_guid(request, 'case_guid')
     collector_guid = get_guid(request, 'collector_guid')
-    _, storage = await prologue(
-        request,
-        'retrieve_collector_secrets',
+    action = Action(
+        name='retrieve_collector_secrets',
         context={'case_guid': case_guid, 'collector_guid': collector_guid},
     )
+    _, storage = await prologue(request, action)
     collector_secrets = await storage.retrieve_collector_secrets(
         case_guid, collector_guid
     )
@@ -600,9 +585,10 @@ async def api_collector_secrets_get(request: Request):
 async def api_collectors_get(request: Request):
     """Enumerate case collectors"""
     case_guid = get_guid(request, 'case_guid')
-    _, storage = await prologue(
-        request, 'enumerate_collectors', context={'case_guid': case_guid}
+    action = Action(
+        name='enumerate_collectors', context={'case_guid': case_guid}
     )
+    _, storage = await prologue(request, action)
     return json_response(
         data=[
             collector.to_dict()

--- a/server/edf_helium_server/api/config.py
+++ b/server/edf_helium_server/api/config.py
@@ -2,6 +2,7 @@
 
 from aiohttp.web import Request
 from edf_fusion.helper.aiohttp import json_response
+from edf_fusion.server.auth import Action
 from edf_fusion.server.config import FusionAnalyzerConfig
 from edf_fusion.server.download import get_fusion_dl_api
 from edf_helium_core.concept import Profile, Rule, Target
@@ -34,9 +35,10 @@ def _get_opsystem(request: Request) -> OperatingSystem | None:
 async def api_profiles_get(request: Request):
     """Retrieve collection profiles for given operating system"""
     opsystem = _get_opsystem(request)
-    _, storage = await prologue(
-        request, 'enumerate_profiles', context={'opsystem': opsystem.value}
+    action = Action(
+        name='enumerate_profiles', context={'opsystem': opsystem.value}
     )
+    _, storage = await prologue(request, action)
     profile_mapping = get_profile_mapping(
         storage.generaptor.cache,
         storage.generaptor.config,
@@ -55,9 +57,10 @@ async def api_profiles_get(request: Request):
 async def api_rules_get(request: Request):
     """Retrieve collection rules for given operating system"""
     opsystem = _get_opsystem(request)
-    _, storage = await prologue(
-        request, 'enumerate_rules', context={'opsystem': opsystem.value}
+    action = Action(
+        name='enumerate_rules', context={'opsystem': opsystem.value}
     )
+    _, storage = await prologue(request, action)
     _, rule_set = get_rule_set(
         storage.generaptor.cache,
         storage.generaptor.config,
@@ -83,9 +86,10 @@ async def api_rules_get(request: Request):
 async def api_targets_get(request: Request):
     """Retrieve collection targets for given operating system"""
     opsystem = _get_opsystem(request)
-    _, storage = await prologue(
-        request, 'enumerate_targets', context={'opsystem': opsystem.value}
+    action = Action(
+        name='enumerate_targets', context={'opsystem': opsystem.value}
     )
+    _, storage = await prologue(request, action)
     max_uid, _ = get_rule_set(
         storage.generaptor.cache,
         storage.generaptor.config,
@@ -107,7 +111,8 @@ async def api_targets_get(request: Request):
 
 async def api_analyzers_get(request: Request):
     """Retrieve analyzers config"""
-    _, storage = await prologue(request, 'enumerate_analyzers')
+    action = Action(name='enumerate_analyzers')
+    _, storage = await prologue(request, action)
     config = get_helium_config(request)
     analyzers = []
     async for analyzer in storage.enumerate_analyzers():
@@ -125,11 +130,11 @@ async def api_collector_template_download_get(request: Request):
     arch = _get_arch(request)
     opsystem = _get_opsystem(request)
     fusion_dl_api = get_fusion_dl_api(request)
-    _, storage = await prologue(
-        request,
-        'download_collector_template',
+    action = Action(
+        name='download_collector_template',
         context={'opsystem': opsystem, 'arch': arch},
     )
+    _, storage = await prologue(request, action)
     template = await storage.retrieve_collector_template(opsystem, arch)
     if not template:
         return json_response(

--- a/server/edf_helium_server/api/disk_usage.py
+++ b/server/edf_helium_server/api/disk_usage.py
@@ -3,7 +3,7 @@
 from aiohttp.web import Request
 from edf_fusion.helper.aiohttp import json_response
 from edf_fusion.helper.datetime import utcnow
-from edf_fusion.server.auth import get_fusion_auth_api
+from edf_fusion.server.auth import Action, get_fusion_auth_api
 from edf_helium_core.concept import DiskUsage
 
 from ..helper.aiohttp import prologue
@@ -11,7 +11,8 @@ from ..helper.aiohttp import prologue
 
 async def api_disk_usage_get(request: Request):
     """Retrieve collection targets for given operating system"""
-    identity, storage = await prologue(request, 'disk_usage', context={})
+    action = Action(name='disk_usage')
+    identity, storage = await prologue(request, action)
     fusion_auth_api = get_fusion_auth_api(request)
     cannot_access_cases = [
         case.guid

--- a/server/edf_helium_server/disk_usage.py
+++ b/server/edf_helium_server/disk_usage.py
@@ -7,6 +7,7 @@ from signal import SIGINT, SIGTERM
 
 from edf_fusion.helper.datetime import utcnow
 from edf_fusion.helper.logging import get_logger
+from edf_fusion.helper.redis import create_redis
 from edf_helium_core.concept import CaseDiskUsage, DiskUsage
 
 from .__version__ import version
@@ -91,5 +92,6 @@ def app():
     except:
         _LOGGER.exception("invalid configuration file: %s", args.config)
         return
-    storage = Storage(config=config.storage)
+    redis = create_redis(config.server.redis_url)
+    storage = Storage(redis=redis, config=config.storage)
     run(_compute_du_loop(storage))

--- a/server/edf_helium_server/helper/aiohttp.py
+++ b/server/edf_helium_server/helper/aiohttp.py
@@ -2,19 +2,17 @@
 
 from aiohttp.web import Request
 from edf_fusion.concept import Identity
-from edf_fusion.server.auth import get_fusion_auth_api
+from edf_fusion.server.auth import Action, get_fusion_auth_api
 from edf_fusion.server.storage import get_fusion_storage
 
 from ..storage import Storage
 
 
 async def prologue(
-    request: Request, operation: str, context: dict | None = None
+    request: Request, action: Action
 ) -> tuple[Identity, Storage]:
     """Determine if authorized and retrieve storage"""
     fusion_auth_api = get_fusion_auth_api(request)
-    identity = await fusion_auth_api.authorize(
-        request, operation, context=context
-    )
+    identity = await fusion_auth_api.authorize(request, action)
     storage = get_fusion_storage(request)
     return identity, storage

--- a/server/edf_helium_server/main.py
+++ b/server/edf_helium_server/main.py
@@ -8,8 +8,17 @@ from edf_fusion.concept import Identity, Info
 from edf_fusion.helper.config import ConfigError
 from edf_fusion.helper.logging import get_logger
 from edf_fusion.helper.redis import setup_redis
-from edf_fusion.server.auth import FusionAuthAPI, get_fusion_auth_api
-from edf_fusion.server.case import FusionCaseAPI
+from edf_fusion.server.auth import (
+    Access,
+    Action,
+    FusionAuthAPI,
+    get_fusion_auth_api,
+)
+from edf_fusion.server.case import (
+    ActionDeleteCase,
+    ActionUpdateCase,
+    FusionCaseAPI,
+)
 from edf_fusion.server.constant import FusionConstantAPI
 from edf_fusion.server.download import FusionDownloadAPI
 from edf_fusion.server.event import FusionEventAPI
@@ -34,10 +43,10 @@ _LOGGER = get_logger('server.main', root='helium')
 
 
 async def _authorize_impl(
-    identity: Identity, request: Request, context: dict
+    request: Request, action: Action, identity: Identity
 ) -> bool:
     storage = get_fusion_storage(request)
-    case_guid = context.get('case_guid')
+    case_guid = action.context.get('case_guid')
     if not case_guid:
         return True
     case = await storage.retrieve_case(case_guid)
@@ -45,14 +54,18 @@ async def _authorize_impl(
         _LOGGER.warning("case not found!")
         return False
     fusion_auth_api = get_fusion_auth_api(request)
-    can_access = fusion_auth_api.can_access_case(identity, case)
-    if not can_access:
+    access = fusion_auth_api.can_access_case(identity, case)
+    if not access or (action.change and access != Access.CHANGE):
         return False
-    case_open_check = context.get('case_open_check')
-    if case_open_check and case.closed:
+    if action.change and case.closed:
+        if isinstance(action, (ActionDeleteCase, ActionUpdateCase)):
+            # allow closed case deletion
+            # allow closed case update to reopen case
+            # (Case.update will prevent closed case modification if not reopen)
+            return True
         _LOGGER.warning("case closed!")
         return False
-    return can_access
+    return True
 
 
 def _parse_args() -> Namespace:
@@ -100,7 +113,7 @@ async def _init_app(config: HeliumServerConfig) -> Application:
     fusion_download_api = FusionDownloadAPI(config=config.download_api)
     fusion_download_api.setup(webapp)
     setup_api(webapp)
-    storage = Storage(config=config.storage)
+    storage = Storage(redis=redis, config=config.storage)
     storage.setup(webapp)
     return webapp
 

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
     "Topic :: Security",
 ]
 dependencies = [
-    "edf-helium-core~=2.0",
+    "edf-helium-core~=3.0",
 ]
 
 

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,3 +1,10 @@
+# =============================================================================
+# FUSION DIRECTIVES
+# =============================================================================
+# fusion:image=cert-edf/helium-fe
+# =============================================================================
+# BUILD IMAGE
+# =============================================================================
 FROM node:22 AS build
 ARG GIT_TAG
 WORKDIR /app
@@ -6,7 +13,9 @@ RUN npm install
 COPY . .
 RUN echo "export const version: string = '${GIT_TAG}';" > /app/public/version.ts
 RUN npm run build
-
+# =============================================================================
+# PRODUCTION IMAGE
+# =============================================================================
 FROM nginx:alpine AS production
 LABEL maintainer="github.com/cert-edf"
 COPY nginx.conf /etc/nginx/nginx.conf


### PR DESCRIPTION
## Changes

- Refactor access control (following fusion 3.0.0 changes)
- Fix extractor analyzer (no need to create a directory that `copytree` will create) 
- Fix analysis log download (missing `await`)
- Give Storage access to Redis instance
- Update Hayabusa analyzer from 3.6.0 to 3.8.1
- Update docker related config files
- Update tests